### PR TITLE
Benodigde tabellen

### DIFF
--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -1,41 +1,116 @@
+# Benodigde tabellen voor Haal Centraal API's
+
 Noot: De landelijke tabellen zijn gepubliceerd op https://publicaties.rvig.nl/Landelijke_tabellen/Landelijke_tabellen_32_t_m_61_excl_tabel_35
 
-Tabellen met als bron een LO GBA element staan beschreven in de [tabelwaarden.feature](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/tabelwaarden.feature)
+## BRP-Personen-Bevragen
 
 Voor de BRP-Personen-Bevragen moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
 
-| tabelidentificatie           | bron                 |
-|------------------------------|----------------------|
-| Aanduiding_Bij_Huisnummer    | LO GBA element 11.50 |
-| Adellijke_Titel_Predicaat    | Landelijke tabel 38  |
-| Europees_Kiesrecht           | LO GBA element 31.10 |
-| Functie_Adres                | LO GBA element 10.10 |
-| Gemeenten                    | Landelijke tabel 33  |
-| Geslacht                     | LO GBA element 04.10 |
-| Gezagsverhouding             | Landelijke tabel 61  |
-| Landen                       | Landelijke tabel 34  |
-| Naamgebruik                  | LO GBA element 61.10 |
-| Nationaliteiten              | Landelijke tabel 32  |
-| Reden_Nationaliteit          | Landelijke tabel 37  |
-| Reden_Opschorting_Bijhouding | LO GBA element 67.20 |
-| Soort_Verbintenis            | LO GBA element 15.10 |
-| Verblijfstitel               | Landelijke tabel 56  |
+| tabelidentificatie           | bron                 | omschrijving                                                                                                                                               |
+|------------------------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Aanduiding_Bij_Huisnummer    | LO GBA element 11.50 | De aanduiding die wordt gebruikt voor adressen die geen straatnaam en huisnummeraanduidingen hebben, maar verwijzen naar een (verblijf)plaats in de buurt. |
+| Adellijke_Titel_Predicaat    | Landelijke tabel 38  | Adellijke titel/predicaat                                                                                                                                  |
+| Europees_Kiesrecht           | LO GBA element 31.10 | Aanduiding van het recht om deel te nemen aan verkiezingen binnen de Europese Unie.                                                                        |
+| Functie_Adres                | LO GBA element 10.10 | Aanduiding van de functie van het adres.                                                                                                                   |
+| Gemeenten                    | Landelijke tabel 33  | Gemeenten                                                                                                                                                  |
+| Geslacht                     | LO GBA element 04.10 | Geeft aan wat het geslacht is van de persoon.                                                                                                              |
+| Gezagsverhouding             | Landelijke tabel 61  | Gezagsverhouding                                                                                                                                           |
+| Landen                       | Landelijke tabel 34  | Landen                                                                                                                                                     |
+| Naamgebruik                  | LO GBA element 61.10 | De manier waarop de geslachtsnaam van persoon en partner van persoon moet worden verwerkt in de manier waarop persoon wil worden aangesproken.             |
+| Nationaliteiten              | Landelijke tabel 32  | Nationaliteiten                                                                                                                                            |
+| Reden_Nationaliteit          | Landelijke tabel 37  | Reden opnemen - beeindigen Nationaliteit                                                                                                                   |
+| Reden_Opschorting_Bijhouding | LO GBA element 67.20 | Reden voor opschorting van de bijhouding.                                                                                                                  |
+| Soort_Verbintenis            | LO GBA element 15.10 | Soort verbintenis tussen de persoon en de partner die bij de burgerlijke stand is ingeschreven.                                                            |
+| Verblijfstitel               | Landelijke tabel 56  | Verblijfstitel                                                                                                                                             |
+
+## BRP-historie
 
 Voor de BRP-historie API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
 
-| tabelidentificatie        | bron                |
-|---------------------------|---------------------|
-| Reden_Beeindigen_Huwelijk | Landelijke tabel 41 |
+| tabelidentificatie        | bron                | omschrijving                                                           |
+|---------------------------|---------------------|------------------------------------------------------------------------|
+| Reden_Beeindigen_Huwelijk | Landelijke tabel 41 | Reden ontbinding nietigverklaring huwelijk geregistreerd partnerschap. |
 
-Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
-
-| tabelidentificatie                | bron                 |
-|-----------------------------------|----------------------|
-| Nederlands_Reisdocument           | Landelijke tabel 48  |
-| Autoriteit_Afgifte_Reisdocument   | Landelijke tabel 49  |
-| Inhouding_Vermissing_Reisdocument | LO GBA element 11.50 |
+## BRP-Bewoning
 
 Voor de BRP-Bewoning API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
-| tabelidentificatie      | bron                                                         |
-|-------------------------|--------------------------------------------------------------|
-| Reden_Bewoning_Onbekend | Types verblijfplaats zonder adresseerbaarObjectIdentivicatie |
+| tabelidentificatie      | bron                                                         | omschrijving                                            |
+|-------------------------|--------------------------------------------------------------|---------------------------------------------------------|
+| Reden_Bewoning_Onbekend | Types verblijfplaats zonder adresseerbaarObjectIdentivicatie | Reden dat bewoning en bewoners niet kan worden bepaald. |
+
+# Mogelijke waarden LO GBA elementen
+
+## Aanduiding_Bij_Huisnummer
+
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code       | omschrijving                     |
+  | ---------- | -------------------------------- |
+  | to         | tegenover                        |
+  | by         | bij                              |
+
+## Geslacht
+  
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code       | omschrijving                     |
+  | ---------- | -------------------------------- |
+  | M          | man                              |
+  | V          | vrouw                            |
+  | O          | onbekend                         |
+
+## Naamgebruik
+
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code       | omschrijving                                                            |
+  | ---------- | ----------------------------------------------------------------------- |
+  | E          | eigen geslachtsnaam                                                     |
+  | N          | geslachtsnaam echtgenoot/geregistreerd partner na eigen geslachtsnaam   |
+  | P          | geslachtsnaam echtgenoot/geregistreerd partner                          |
+  | V          | geslachtsnaam echtgenoot/geregistreerd partner voor eigen geslachtsnaam |
+
+## Reden_Opschorting_Bijhouding
+
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code       | omschrijving              |
+  | ---------- | ------------------------- |
+  | O          | overlijden                |
+  | E          | emigratie                 |
+  | M          | ministerieel besluit      |
+  | R          | pl is aangelegd in de rni |
+  | F          | fout                      |
+  | .          | onbekend                  |
+
+## Soort_Verbintenis
+
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code       | omschrijving                         |
+  | ---------- | ------------------------------------ |
+  | H          | huwelijk                             |
+  | P          | geregistreerd partnerschap           |
+  | .          | onbekend                             |
+
+## Functie_Adres
+
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code       | omschrijving                         |
+  | ---------- | ------------------------------------ |
+  | W          | woonadres                            |
+  | B          | briefadres                           |
+
+## Europees_Kiesrecht
+
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code       | omschrijving                         |
+  | ---------- | ------------------------------------ |
+  | 1          | persoon is uitgesloten               |
+  | 2          | persoon ontvangt oproep              |
+
+
+## Reden_Bewoning_Onbekend
+  
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code             | omschrijving                                                                                  |
+  | ----------       | ------------------------------------                                                          |
+  | NIET_ADRES_ADRES | voor een adres zonder BAG adresseerbaar object identificatie kan geen bewoning worden bepaald |
+  | LOCATIE          | voor een locatiebeschrijving kan geen bewoning worden bepaald                                 |
+  | BUITENLAND       | voor een verblijfplaats in het buitenland kan geen bewoning worden bepaald                    |
+  | ONBEKEND         | de verblijfplaats is onbekend                                                                 |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -2,6 +2,8 @@
 
 Noot: De landelijke tabellen zijn gepubliceerd op https://publicaties.rvig.nl/Landelijke_tabellen/Landelijke_tabellen_32_t_m_61_excl_tabel_35
 
+Mogelijke waarden van LO GBA elementen staan in tabelwaarden.csv
+
 ## BRP-Personen-Bevragen
 
 Voor de BRP-Personen-Bevragen moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
@@ -34,100 +36,14 @@ Voor de BRP-historie API moeten minimaal de volgende tabellen beschikbaar worden
 ## BRP-Bewoning
 
 Voor de BRP-Bewoning API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
-| tabelidentificatie      | bron                                                         | omschrijving                                            |
-|-------------------------|--------------------------------------------------------------|---------------------------------------------------------|
-| Reden_Bewoning_Onbekend | Types verblijfplaats zonder adresseerbaarObjectIdentivicatie | Reden dat bewoning en bewoners niet kan worden bepaald. |
+| tabelidentificatie      | bron             | omschrijving                                            |
+|-------------------------|------------------|---------------------------------------------------------|
+| Reden_Bewoning_Onbekend | tabelwaarden.csv | Reden dat bewoning en bewoners niet kan worden bepaald. |
 
 ## Reisdocumenten-bevragen
 
-Voor de Reisdocumenten-bevragen moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
-| tabelidentificatie      | bron                          | omschrijving                    |
-|-------------------------|-------------------------------|---------------------------------|
-| Nederlands_Reisdocument | Landelijke tabel 48           | Nederlands Reisdocument         |
-| Geldig_Reisdocument     | geldig, niet-geldig, onbekend | Geldigheid van een reisdocument |
-
-# Mogelijke waarden LO GBA elementen
-
-## Aanduiding_Bij_Huisnummer
-
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code       | omschrijving                     |
-  | ---------- | -------------------------------- |
-  | to         | tegenover                        |
-  | by         | bij                              |
-
-## Geslacht
-  
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code       | omschrijving                     |
-  | ---------- | -------------------------------- |
-  | M          | man                              |
-  | V          | vrouw                            |
-  | O          | onbekend                         |
-
-## Naamgebruik
-
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code       | omschrijving                                                            |
-  | ---------- | ----------------------------------------------------------------------- |
-  | E          | eigen geslachtsnaam                                                     |
-  | N          | geslachtsnaam echtgenoot/geregistreerd partner na eigen geslachtsnaam   |
-  | P          | geslachtsnaam echtgenoot/geregistreerd partner                          |
-  | V          | geslachtsnaam echtgenoot/geregistreerd partner voor eigen geslachtsnaam |
-
-## Reden_Opschorting_Bijhouding
-
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code       | omschrijving              |
-  | ---------- | ------------------------- |
-  | O          | overlijden                |
-  | E          | emigratie                 |
-  | M          | ministerieel besluit      |
-  | R          | pl is aangelegd in de rni |
-  | F          | fout                      |
-  | .          | onbekend                  |
-
-## Soort_Verbintenis
-
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code       | omschrijving                         |
-  | ---------- | ------------------------------------ |
-  | H          | huwelijk                             |
-  | P          | geregistreerd partnerschap           |
-  | .          | onbekend                             |
-
-## Functie_Adres
-
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code       | omschrijving                         |
-  | ---------- | ------------------------------------ |
-  | W          | woonadres                            |
-  | B          | briefadres                           |
-
-## Europees_Kiesrecht
-
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code       | omschrijving                         |
-  | ---------- | ------------------------------------ |
-  | 1          | persoon is uitgesloten               |
-  | 2          | persoon ontvangt oproep              |
-
-
-## Reden_Bewoning_Onbekend
-  
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code             | omschrijving                                                                                  |
-  | ----------       | ------------------------------------                                                          |
-  | NIET_ADRES_ADRES | voor een adres zonder BAG adresseerbaar object identificatie kan geen bewoning worden bepaald |
-  | LOCATIE          | voor een locatiebeschrijving kan geen bewoning worden bepaald                                 |
-  | BUITENLAND       | voor een verblijfplaats in het buitenland kan geen bewoning worden bepaald                    |
-  | ONBEKEND         | de verblijfplaats is onbekend                                                                 |
-
-## Geldig_Reisdocument
-
-  In de waardetabel worden de volgende waarden opgenomen:
-  | code | omschrijving                               |
-  |------|--------------------------------------------|
-  | G    | Reisdocument is geldig                     |
-  | N    | Reisdocument is niet geldig                |
-  | O    | De status van het reisdocument is onbekend |
+Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
+| tabelidentificatie      | bron                | omschrijving                    |
+|-------------------------|---------------------|---------------------------------|
+| Nederlands_Reisdocument | Landelijke tabel 48 | Nederlands Reisdocument         |
+| Geldig_Reisdocument     | tabelwaarden.csv    | Geldigheid van een reisdocument |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -32,4 +32,5 @@ Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschik
 | tabelidentificatie                | bron                 |
 |-----------------------------------|----------------------|
 | Nederlands_Reisdocument           | Landelijke tabel 48  |
+| Autoriteit_Afgifte_Reisdocument   | Landelijke tabel 49  |
 | Inhouding_Vermissing_Reisdocument | LO GBA element 11.50 |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -41,9 +41,10 @@ Voor de BRP-Bewoning API moeten minimaal de volgende tabellen beschikbaar worden
 ## Reisdocumenten-bevragen
 
 Voor de Reisdocumenten-bevragen moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
-| tabelidentificatie      | bron                                                         | omschrijving                                            |
-|-------------------------|--------------------------------------------------------------|---------------------------------------------------------|
-| Nederlands_Reisdocument | Landelijke tabel 48 | Nederlands Reisdocument |
+| tabelidentificatie      | bron                          | omschrijving                    |
+|-------------------------|-------------------------------|---------------------------------|
+| Nederlands_Reisdocument | Landelijke tabel 48           | Nederlands Reisdocument         |
+| Geldig_Reisdocument     | geldig, niet-geldig, onbekend | Geldigheid van een reisdocument |
 
 # Mogelijke waarden LO GBA elementen
 
@@ -121,3 +122,12 @@ Voor de Reisdocumenten-bevragen moeten minimaal de volgende tabellen beschikbaar
   | LOCATIE          | voor een locatiebeschrijving kan geen bewoning worden bepaald                                 |
   | BUITENLAND       | voor een verblijfplaats in het buitenland kan geen bewoning worden bepaald                    |
   | ONBEKEND         | de verblijfplaats is onbekend                                                                 |
+
+## Geldig_Reisdocument
+
+  In de waardetabel worden de volgende waarden opgenomen:
+  | code | omschrijving                               |
+  |------|--------------------------------------------|
+  | G    | Reisdocument is geldig                     |
+  | N    | Reisdocument is niet geldig                |
+  | O    | De status van het reisdocument is onbekend |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -4,7 +4,7 @@ Tabellen met als bron een LO GBA element staan beschreven in de [tabelwaarden.fe
 
 Voor de BRP-Personen-Bevragen moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
 
-| tabelidentificatie           | bron voor waarden    |
+| tabelidentificatie           | bron                 |
 |------------------------------|----------------------|
 | Aanduiding_Bij_Huisnummer    | LO GBA element 11.50 |
 | Adellijke_Titel_Predicaat    | Landelijke tabel 38  |
@@ -16,10 +16,16 @@ Voor de BRP-Personen-Bevragen moeten minimaal de volgende tabellen beschikbaar w
 | Landen                       | Landelijke tabel 34  |
 | Naamgebruik                  | LO GBA element 61.10 |
 | Nationaliteiten              | Landelijke tabel 32  |
-| Reden_Opschorting_Bijhouding | LO GBA element 67.20 |
 | Reden_Nationaliteit          | Landelijke tabel 37  |
+| Reden_Opschorting_Bijhouding | LO GBA element 67.20 |
 | Soort_Verbintenis            | LO GBA element 15.10 |
 | Verblijfstitel               | Landelijke tabel 56  |
+
+Voor de BRP-historie API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
+
+| tabelidentificatie        | bron                |
+|---------------------------|---------------------|
+| Reden_Beeindigen_Huwelijk | Landelijke tabel 41 |
 
 Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
 

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -19,3 +19,9 @@ Voor de BRP-Personen-Bevragen moeten minimaal de volgende tabellen beschikbaar w
 | Reden opname/beëindigen nationaliteit | Landelijke tabel 37                                          |                                           |
 | SoortVerbintenis                      | Mogelijke waarden uit LO GBA 3.14 Element 15.10              | Soort verbintenis                         |
 | Verblijfstitel                        | Landelijke tabbel 56                                         |                                           |
+
+Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
+
+| tabelidentificatie                | bron voor waarden               | 
+| --------------------------------- | ------------------------------- |
+| Inhouding_Vermissing_Reisdocument | mogelijke waarden element 11.50 |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -27,7 +27,7 @@ Voor de BRP-Personen-Bevragen moeten minimaal de volgende tabellen beschikbaar w
 
 ## BRP-historie
 
-Voor de BRP-historie API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
+Voor de BRP-historie API moeten minimaal de volgende tabellen beschikbaar worden gemaakt (bovenop wat voor BRP-Personen-Bevragen aan tabellen gevraagd is):
 
 | tabelidentificatie        | bron                | omschrijving                                                           |
 |---------------------------|---------------------|------------------------------------------------------------------------|
@@ -35,7 +35,7 @@ Voor de BRP-historie API moeten minimaal de volgende tabellen beschikbaar worden
 
 ## BRP-Bewoning
 
-Voor de BRP-Bewoning API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
+Voor de BRP-Bewoning API moeten minimaal de volgende tabellen beschikbaar worden gemaakt (bovenop wat voor BRP-Personen-Bevragen aan tabellen gevraagd is):
 | tabelidentificatie      | bron             | omschrijving                                            |
 |-------------------------|------------------|---------------------------------------------------------|
 | Reden_Bewoning_Onbekend | tabelwaarden.csv | Reden dat bewoning en bewoners niet kan worden bepaald. |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -31,4 +31,5 @@ Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschik
 
 | tabelidentificatie                | bron                 |
 |-----------------------------------|----------------------|
+| Nederlands_Reisdocument           | Landelijke tabel 48  |
 | Inhouding_Vermissing_Reisdocument | LO GBA element 11.50 |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -1,27 +1,28 @@
 Noot: De landelijke tabellen zijn gepubliceerd op https://publicaties.rvig.nl/Landelijke_tabellen/Landelijke_tabellen_32_t_m_61_excl_tabel_35
 
+Tabellen met als bron een LO GBA element staan beschreven in de [tabelwaarden.feature](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/tabelwaarden.feature)
+
 Voor de BRP-Personen-Bevragen moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
 
-| tabel                                 | bron                                                         | veld                                      |
-| ------------------------------------- | ------------------------------------------------------------ | ----------------------------------------- |
-| Aanduiding bij huisnummer             | Mogelijke waarden uit het LO GBA Element 11.50               | Aanduiding bij huisnummer                 |
-| Aanduiding bijzonder Nederlanderschap | Mogelijke waarden uit het LO GBA Element 65.10               | Aanduiding bijzonder Nederlanderschap     |
-| AdellijkeTitelPredicaat               | Landelijke tabel 38                                          |                                           |
-| EuropeesKiesrecht                     | Mogelijke waarden uit het LO GBA Element 31.10               | Europees Kiesrecht                        |
-| FunctieAdres                          | Mogelijke waarden uit het LO GBA Element 10.10               | Functie Adres                             |
-| Gemeenten                             | Landelijke tabel 33                                          |                                           |
-| Geslacht                              | Mogelijke waarden uit het LO GBA 3.14 Element 04.10          | Geslachtsaanduiding                       |
-| Gezagsverhouding                      | Landelijke tabel 61                                          |                                           |
-| Landen                                | Landelijke tabel 34                                          |                                           |
-| Naamgebruik                           | Mogelijke waarden uit het LO GBA Element 61.10               | Aanduiding naamgebruik                    |
-| Nationaliteiten                       | Landelijke tabel 32                                          |                                           |
-| RedenopschortingBijhouding            | Mogelijke waarden uit LO GBA 3.14 Element 67.20              | Omschrijving Reden Opschorting Bijhouding |
-| Reden opname/beëindigen nationaliteit | Landelijke tabel 37                                          |                                           |
-| SoortVerbintenis                      | Mogelijke waarden uit LO GBA 3.14 Element 15.10              | Soort verbintenis                         |
-| Verblijfstitel                        | Landelijke tabbel 56                                         |                                           |
+| tabelidentificatie           | bron voor waarden    |
+|------------------------------|----------------------|
+| Aanduiding_Bij_Huisnummer    | LO GBA element 11.50 |
+| Adellijke_Titel_Predicaat    | Landelijke tabel 38  |
+| Europees_Kiesrecht           | LO GBA element 31.10 |
+| Functie_Adres                | LO GBA element 10.10 |
+| Gemeenten                    | Landelijke tabel 33  |
+| Geslacht                     | LO GBA element 04.10 |
+| Gezagsverhouding             | Landelijke tabel 61  |
+| Landen                       | Landelijke tabel 34  |
+| Naamgebruik                  | LO GBA element 61.10 |
+| Nationaliteiten              | Landelijke tabel 32  |
+| Reden_Opschorting_Bijhouding | LO GBA element 67.20 |
+| Reden_Nationaliteit          | Landelijke tabel 37  |
+| Soort_Verbintenis            | LO GBA element 15.10 |
+| Verblijfstitel               | Landelijke tabel 56  |
 
 Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
 
-| tabelidentificatie                | bron voor waarden               | 
-| --------------------------------- | ------------------------------- |
-| Inhouding_Vermissing_Reisdocument | mogelijke waarden element 11.50 |
+| tabelidentificatie                | bron                 |
+|-----------------------------------|----------------------|
+| Inhouding_Vermissing_Reisdocument | LO GBA element 11.50 |

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -38,6 +38,13 @@ Voor de BRP-Bewoning API moeten minimaal de volgende tabellen beschikbaar worden
 |-------------------------|--------------------------------------------------------------|---------------------------------------------------------|
 | Reden_Bewoning_Onbekend | Types verblijfplaats zonder adresseerbaarObjectIdentivicatie | Reden dat bewoning en bewoners niet kan worden bepaald. |
 
+## Reisdocumenten-bevragen
+
+Voor de Reisdocumenten-bevragen moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
+| tabelidentificatie      | bron                                                         | omschrijving                                            |
+|-------------------------|--------------------------------------------------------------|---------------------------------------------------------|
+| Nederlands_Reisdocument | Landelijke tabel 48 | Nederlands Reisdocument |
+
 # Mogelijke waarden LO GBA elementen
 
 ## Aanduiding_Bij_Huisnummer

--- a/docs/Benodigde-tabellen.md
+++ b/docs/Benodigde-tabellen.md
@@ -34,3 +34,8 @@ Voor de Reisdocumenten-bevragen API moeten minimaal de volgende tabellen beschik
 | Nederlands_Reisdocument           | Landelijke tabel 48  |
 | Autoriteit_Afgifte_Reisdocument   | Landelijke tabel 49  |
 | Inhouding_Vermissing_Reisdocument | LO GBA element 11.50 |
+
+Voor de BRP-Bewoning API moeten minimaal de volgende tabellen beschikbaar worden gemaakt:
+| tabelidentificatie      | bron                                                         |
+|-------------------------|--------------------------------------------------------------|
+| Reden_Bewoning_Onbekend | Types verblijfplaats zonder adresseerbaarObjectIdentivicatie |

--- a/docs/tabelwaarden.csv
+++ b/docs/tabelwaarden.csv
@@ -1,0 +1,30 @@
+tabelidentificatie,code,omschrijving
+Aanduiding_Bij_Huisnummer,to,tegenover
+Aanduiding_Bij_Huisnummer,by,bij
+Geslacht,M,man
+Geslacht,V,vrouw
+Geslacht,O,onbekend
+Naamgebruik,E,eigen geslachtsnaam
+Naamgebruik,N,geslachtsnaam echtgenoot/geregistreerd partner na eigen geslachtsnaam
+Naamgebruik,P,geslachtsnaam echtgenoot/geregistreerd partner
+Naamgebruik,V,geslachtsnaam echtgenoot/geregistreerd partner voor eigen geslachtsnaam
+Reden_Opschorting_Bijhouding,O,overlijden
+Reden_Opschorting_Bijhouding,E,emigratie
+Reden_Opschorting_Bijhouding,M,ministerieel besluit
+Reden_Opschorting_Bijhouding,R,pl is aangelegd in de rni
+Reden_Opschorting_Bijhouding,F,fout
+Reden_Opschorting_Bijhouding,.,onbekend
+Soort_Verbintenis,H,huwelijk
+Soort_Verbintenis,P,geregistreerd partnerschap
+Soort_Verbintenis,.,onbekend
+Functie_Adres,W,woonadres
+Functie_Adres,B,briefadres
+Europees_Kiesrecht,1,persoon is uitgesloten
+Europees_Kiesrecht,2,persoon ontvangt oproep
+Reden_Bewoning_Onbekend,NIET_ADRES_ADRES,voor een adres zonder BAG adresseerbaar object identificatie kan geen bewoning worden bepaald
+Reden_Bewoning_Onbekend,LOCATIE,voor een locatiebeschrijving kan geen bewoning worden bepaald
+Reden_Bewoning_Onbekend,BUITENLAND,voor een verblijfplaats in het buitenland kan geen bewoning worden bepaald
+Reden_Bewoning_Onbekend,ONBEKEND,de verblijfplaats is onbekend
+Geldig_Reisdocument,G,Reisdocument is geldig
+Geldig_Reisdocument,N,Reisdocument is niet geldig
+Geldig_Reisdocument,O,De status van het reisdocument is onbekend


### PR DESCRIPTION
- toevoegen tabel voor BRP historie API
- toevoegen tabel voor Bewoning API
- correcte tabelidentificaties
- tabellen vereenvoudigen: tabel beperken tot tabelidentificatie en bron
- toevoegen verwijzing naar tabelwaarden.feature
- toevoegen omschrijvingen bij elke tabel
- toevoegen tabelwaarden, overgenomen uit https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/tabelwaarden.feature